### PR TITLE
Pre 1.4 improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "echo \"Tests here...\""
   },
   "dependencies": {
-    "@lottiefiles/dotlottie-react": "^0.19.5",
+    "@lottiefiles/dotlottie-react": "^0.19.7",
     "@mantine/core": "^9.4.1",
     "@mantine/hooks": "^9.4.1",
     "@mantine/modals": "^9.4.1",
@@ -37,10 +37,10 @@
     "react-router": "^8.1.0"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.5.1",
+    "@biomejs/biome": "^2.5.2",
     "@rolldown/plugin-babel": "^0.2.3",
     "@types/lodash-es": "^4.17.12",
-    "@types/node": "^26.0.1",
+    "@types/node": "^26.1.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
@@ -49,7 +49,7 @@
     "postcss-preset-mantine": "^1.18.0",
     "postcss-simple-vars": "^7.0.1",
     "typescript": "^6.0.3",
-    "vite": "^8.1.0",
+    "vite": "^8.1.3",
     "vite-plugin-pwa": "^1.3.0",
     "workbox-build": "^7.4.1",
     "workbox-core": "^7.4.1",
@@ -60,5 +60,5 @@
       "vite": "$vite"
     }
   },
-  "packageManager": "pnpm@11.5.3+sha512.7ac1c919341c213a34dc0d02afb7143c5c26ac26ee8c4782deea821b8ac64d2134a081fd8941dae6e29bbb48f58dfc2b7fbceeccc07cb2f09d219d342a4969ed"
+  "packageManager": "pnpm@11.10.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@lottiefiles/dotlottie-react':
-        specifier: ^0.19.5
-        version: 0.19.5(react@19.2.7)
+        specifier: ^0.19.7
+        version: 0.19.7(react@19.2.7)
       '@mantine/core':
         specifier: ^9.4.1
         version: 9.4.1(@mantine/hooks@9.4.1(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -70,17 +70,17 @@ importers:
         version: 8.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.5.1
-        version: 2.5.1
+        specifier: ^2.5.2
+        version: 2.5.2
       '@rolldown/plugin-babel':
         specifier: ^0.2.3
-        version: 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0))
+        version: 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0))
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
       '@types/node':
-        specifier: ^26.0.1
-        version: 26.0.1
+        specifier: ^26.1.0
+        version: 26.1.0
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -89,7 +89,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^6.0.3
-        version: 6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0))
+        version: 6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0))
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -106,11 +106,11 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
       vite:
-        specifier: ^8.1.0
-        version: 8.1.0(@types/node@26.0.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0)
+        specifier: ^8.1.3
+        version: 8.1.3(@types/node@26.1.0)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0)
       vite-plugin-pwa:
         specifier: ^1.3.0
-        version: 1.3.0(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
+        version: 1.3.0(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0))(workbox-build@7.4.1)(workbox-window@7.4.1)
       workbox-build:
         specifier: ^7.4.1
         version: 7.4.1
@@ -630,59 +630,59 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@2.5.1':
-    resolution: {integrity: sha512-IXWLCxKmae+rI7LOHS1B3EbVisQ6GRAWbhN9msa6KjNCyFWrvKZWR4oUdinaNssrV852OrSHuSPa95h1GPJc7Q==}
+  '@biomejs/biome@2.5.2':
+    resolution: {integrity: sha512-VQ3RCqr7JmDIX+w6stWYl+g/3bYofN3q2wDBHUKKc/c7i5QWrFKFBZYCYPWTE6agsUPMIZZe6/CMmVUfUAhkKA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.5.1':
-    resolution: {integrity: sha512-npqDzvqv7vFaWRiNN1Te71siRgPaqS9MpqgYCdP/CrUbkJ7ApezaeaKjueKHRN/JH/6lRjJQAHi8acQDCAz22w==}
+  '@biomejs/cli-darwin-arm64@2.5.2':
+    resolution: {integrity: sha512-e7P3P7EkwFc/KiX2AHw4YDLIBOMfG9CPCAwy52k5Bp0dfhkozx9hf6wCmIr2QeXy2XeccJ3V/Sg+hDmzYEqxSg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.5.1':
-    resolution: {integrity: sha512-RgwTqPAM8g2tn1j+b5oRjF/DbSBX8a4gwojtuG9XuhfK7GgomvZ9+T+tqjXiVbjLEeGJOoL6VEk8mvRTVeSybw==}
+  '@biomejs/cli-darwin-x64@2.5.2':
+    resolution: {integrity: sha512-ymzMvjC1Jg0b9K0D26ZdARqFQXs7MocfLC5FOCGfkC0Ss+ACUJkX5364ZM5nT4NLZanHRZNVrZEy+Ibwcvux/g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.5.1':
-    resolution: {integrity: sha512-WMcvMLgByyTqVxGlq918NBBYliq9FRR9GAQVETHb+VjGVqXCZFfHlZHC1FX4ibuYY/Hg6TJE3rHU0xVrdJXNRw==}
+  '@biomejs/cli-linux-arm64-musl@2.5.2':
+    resolution: {integrity: sha512-w+ANG0ZvTu9IeEg9QnstoOnk6L0fpwJifW6aHR18+cb5Z39bkANItYjAfMrnvce5tmMK+IQ6nPX7/kQFdam5iw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.5.1':
-    resolution: {integrity: sha512-yhV35CzZh38VyMvTEXi3JTjxZBs++oCKK9KG8vB6VI5+uvQvZNR3BFWEKKzuOmx9DJJj7sQpZ4LQJcmbGTs3+Q==}
+  '@biomejs/cli-linux-arm64@2.5.2':
+    resolution: {integrity: sha512-t7sseOmqND57uUWTwlawU6BYj+J06T/9EkydzBhkrgw/FK3QVhjU2wsJR0frljrKZ0/I8A/rYw7284QgqjQfIQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.5.1':
-    resolution: {integrity: sha512-ANTowtlLmPYm5yeMckWY8Xzb9Ix+JJP3tgHR/n6xRj1VWyIzzWtfRfih9hv9VmClwadpBvZduISZIbBsIlYG3A==}
+  '@biomejs/cli-linux-x64-musl@2.5.2':
+    resolution: {integrity: sha512-VArNLAzND063tF+XY0yPyM+DyahpzOMzOAvb7qs259nhjJWRjvjZdssuA+Rfl+l07+NOesKZ0Xu2yFrXyBMtzw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.5.1':
-    resolution: {integrity: sha512-J/7uHSX7NfoYDI7HijAkd8lnQIOrRb2W7j3X+tw4R+N5ExvXGsyXFiGdQcfcxfOmNQmZVSQOCDk757fwpzqQcg==}
+  '@biomejs/cli-linux-x64@2.5.2':
+    resolution: {integrity: sha512-M/lOZrewzTCRDINbjhQ1gYYru37KlD3kJBQwwKCG0ckz5E9IZwIoJ3X0wBwRXA+yBDIwWUuPBHS67HzJY4dTfA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.5.1':
-    resolution: {integrity: sha512-zgXnKNgWPC4iPF7Y1lR3STUeCUuZRpD6IiOrC7TZTlh0Lx6FiVUT05myuMQHQ9D+1cc7uyMldi4forE6lp0ivQ==}
+  '@biomejs/cli-win32-arm64@2.5.2':
+    resolution: {integrity: sha512-kbjFFKyZlzYnAuw7sRy5qDoFG6zrP40UK08oPQsWK0ct3NMnGSt+Bs1iviEEyEIP57N5MrykGXdO/wRiaR4lww==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.5.1':
-    resolution: {integrity: sha512-6uxpR9hvaglANkZemeSiN/FhYgkGasrEGn267eXIWvjrjJ2LhDlk251IhjVJq6MXzkV2/bcXwLwSroLyPtqRZg==}
+  '@biomejs/cli-win32-x64@2.5.2':
+    resolution: {integrity: sha512-4InchVpdVmdkkkgjQqKpgvyu+VPnoF/7RPSw5YATgEVpt2j72wcCAeV5TwaE9ZGJUZWZn7v2CwSAj6CrMJEx8A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -740,14 +740,14 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@lottiefiles/dotlottie-react@0.19.5':
-    resolution: {integrity: sha512-lkGPsdabX/GBWsOHabKdfa44DORg35W/r5bW4mnV2igomdP7a6OAJJe1A+/rWKYSuN/Cd7eJ8dpXLM+7h7182A==}
+  '@lottiefiles/dotlottie-react@0.19.7':
+    resolution: {integrity: sha512-uozfELOplVo0PwD2E3yy9IndpjKVa4oWErDWFos3cHaqwsUrRLlJNpRDM8aFsWdw5e3N3/GHbKcsGxSeytsPWg==}
     engines: {node: '>=18.17.0', npm: '>=9.5.0'}
     peerDependencies:
       react: ^17 || ^18 || ^19
 
-  '@lottiefiles/dotlottie-web@0.75.0':
-    resolution: {integrity: sha512-2IZAIK7TblPPxSsjmPsDrSDew2XYj422rWKmwjIUPH+zroUPK6/gImjkKoJhKOXzByLEo5bTPx9qW4DCZfM5/g==}
+  '@lottiefiles/dotlottie-web@0.76.0':
+    resolution: {integrity: sha512-uWJ86UJM6hjN4MY2aGSyyFcRQEAM4B9qDCnb/336dHab1zE6nyOF45b90t8xesZPwNtP/2moNGMrMQ1UJW6+lQ==}
     engines: {node: '>=18.17.0', npm: '>=9.5.0'}
 
   '@mantine/core@9.4.1':
@@ -797,100 +797,100 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@oxc-project/types@0.137.0':
-    resolution: {integrity: sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==}
+  '@oxc-project/types@0.138.0':
+    resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
 
-  '@rolldown/binding-android-arm64@1.1.3':
-    resolution: {integrity: sha512-DT6Z3PhvioeHMvxo+xHc3KtqggrI7CCTXCmC2h/5zUlp5jVitv7XEy+9q5/7v8IolhlioawpMo8Kg0EEBy7J0g==}
+  '@rolldown/binding-android-arm64@1.1.4':
+    resolution: {integrity: sha512-EZLpf/8y7GXkkra90ML47kzik/GMP3EMcE9bPyHmRfxLC6z9+aW5A8poCsoxjrT5GfEcNAAvWwUHjvP1pUQkfw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.1.3':
-    resolution: {integrity: sha512-0NwgwsjM7LrsuVnXMK3koTpagBNOhloc/BNjKqZjv4V5zI5r13qx69uVhRx+o5Z0yy4Hzq+lpy7TAgUG/ocvrw==}
+  '@rolldown/binding-darwin-arm64@1.1.4':
+    resolution: {integrity: sha512-aUi+HBvmYb7j8krl1+qJgkG8C17fO79gk3c+jPw4S8glRFc1DTija9S3EyaTSQUm5GJXYKDAsugBEhFHH2vYiQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.1.3':
-    resolution: {integrity: sha512-YtiBp4disu6V560loT6PjMdiRaWmVvDNrUunAalbiFx2ggeJwxdAsgZMcoGP17uyAsTwAj5V1niksxlHnVQ1Sw==}
+  '@rolldown/binding-darwin-x64@1.1.4':
+    resolution: {integrity: sha512-F7hHC3gwY11+vByKPRWqwGbeXWVgKmL+pTGCinaEhdihzBV2aQ0fvZOch9cXYUOKuKKq429HeYXOqQLc7wFCEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.1.3':
-    resolution: {integrity: sha512-yD3EkEdXk2LypPxnf/kSZHirarsI8gcPzc62SukhR9VJTyvV+F9Q/GxWNuCojc7sXyuVC4DxRGhdDK4X8VSsbw==}
+  '@rolldown/binding-freebsd-x64@1.1.4':
+    resolution: {integrity: sha512-sI5yw+7s92SK6odiEhD5lKCBlWcpjHS5qyqpVQbZAJ0fIzEUXrmbl3DH2ybR3PZogulNJF+COLtmA8hUfvkCCQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.3':
-    resolution: {integrity: sha512-c+8vieQbsD7HNAHKIA34w0GJ9FedFFuJGD+7E6vz7Q3uqAIugL5p45fhlsj4UaAsHpcmlqugBWMhA0/j7o0sIg==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
+    resolution: {integrity: sha512-mCi0OKgEieFircrtVYmQAFGszRtMnZ6fpZAXrxanXAu7lqZcsK1E1RAaZNG0uKAnxox3B1f4EyQNnoyMfN1vAA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.3':
-    resolution: {integrity: sha512-50jD0uUwLvur7Zz9LHz17kaAdTPjn5wN93hEgjvmYFRZwiR7ZJYovTd5ipyWJDAnXKvZ+wgc+/Ika6dwSF5OcA==}
+  '@rolldown/binding-linux-arm64-gnu@1.1.4':
+    resolution: {integrity: sha512-B9Ial3Kv5sh0SHnB1g/QWcUQCEvCF6QKGAl4zXypYj65mVI+B4AhFBwPtSN7pDrJeIx8Z7zdy4ntx+wQABom7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.1.3':
-    resolution: {integrity: sha512-BO9+oPL8K9poZJBfYPsXNtYjPE5uM3qeehT3aFcW4LITOl+iSqhp0abzjR2nWBUNjIZeKXjAEWBZ64WjNoHd6w==}
+  '@rolldown/binding-linux-arm64-musl@1.1.4':
+    resolution: {integrity: sha512-lZVym0PuHE1KZ22gmFTC15lAkrg9iTszR617oYRB/iPY1A56ywoJzVKOJBKaot5RiikCObmur6pogpse3gRcng==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.3':
-    resolution: {integrity: sha512-f3VpLB1vQ0Eo6ecr/6cekLnvYMFF4YBFoVGkfkvPLq1bAkbAwHYQPZKoAmG6OJyTcxxoC+AvezGx/S1obNC0Mw==}
+  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
+    resolution: {integrity: sha512-t2DNiLJWNTbnEHyUzTumldML6ET4/g16467LZoDDJ3tSxGvguL5/NyC2lCsNKuyRycg9XeDQF5SSv+TNOhQEXg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.3':
-    resolution: {integrity: sha512-AmurZ26Pqx/RI9N1gzEOCklkKXl927yjfXWUUS0O7Puh8ARM/Ob8qfrD3qnWksScdw6cSrW5PSHE9DyLu7+PtA==}
+  '@rolldown/binding-linux-s390x-gnu@1.1.4':
+    resolution: {integrity: sha512-0WIRnL1Uw4BvTZRLQt+PVgo6ZKTJadlC2btP+/EOXv2f/DWbY0rEgl+y834mIVwP1FkTlWVTrGGJXf12lru7EQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.1.3':
-    resolution: {integrity: sha512-JJpqs8bRGITDOdbkNKnlojzBabbOHrqjSvDr0IVsZObE1lBcPjxItUEY9eWIDbxaJ3cGrXPWGfGkIxFijg/URg==}
+  '@rolldown/binding-linux-x64-gnu@1.1.4':
+    resolution: {integrity: sha512-JWtGshGfX+oENAKonoNkqEJX+7hC8yfhi9GUyPX1VX4mdh1y5r+ZiJLR5XzAB0aoP6s/PcILsGjKq8O0mm24bw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.1.3':
-    resolution: {integrity: sha512-rSJcdjPxzA/by/6/rYs+v+bXU7UjvnbUWz8MJb6kh6+knqB1dCrtHg0uu7C/4haqJvqdkYHQ5IGn+tCH9GLW/g==}
+  '@rolldown/binding-linux-x64-musl@1.1.4':
+    resolution: {integrity: sha512-rT6yQcxUuXs4CnbofqwHRRV0iem349rLMYpTjkgQGLjrY4ado/eDzwPZPTCgTOlF6Nkp8NEv70yLMTn6qkWxsQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.1.3':
-    resolution: {integrity: sha512-hQ3/PYkDJICgevvyNcVrihVeqq7k1Pp3VZ9lY+dauAYUJKO+auqApvANhvR1An9BhmqYKvW2Mu1F9u4DXSMLxQ==}
+  '@rolldown/binding-openharmony-arm64@1.1.4':
+    resolution: {integrity: sha512-KXMGoboq5cyaCQjDA4GLuRiOwBQ0EyFnJoVViLeZ45/3rFItRODEr+NdsBcVpll40hhNArlm/speWGRvj08LzA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.1.3':
-    resolution: {integrity: sha512-Elcv/BtML9lXrV6JuKITc/grN2kYV9gjsQpW8Jfw4ioK0TOkjBjye0nnyqQNy9STNaI20lXNaQBRrD5gSgR0Yg==}
+  '@rolldown/binding-wasm32-wasi@1.1.4':
+    resolution: {integrity: sha512-5K83rb36oJiY7BCyE9zLZtGcPV4g5wvq+xwdO0XPIwDVZI8cyB/AUjkNXGb92/rnmezEkjMOpgY61rtwjQtFwg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.3':
-    resolution: {integrity: sha512-2DrEfhluH9yhiaFApmsjsjwrSYbNcY1oFTzYSP1a535jDbV98zCFanA/96TBUd0iDFcxGmw9QRExwGCXz3U+/g==}
+  '@rolldown/binding-win32-arm64-msvc@1.1.4':
+    resolution: {integrity: sha512-PnWBtw3TV5KOg69HQQDR0mnQuyCmSGR2pAB4DC1rPF808fgKeTUMj2EOEyKATpgiuxuR5APQmiDO7PDgEjTFSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.1.3':
-    resolution: {integrity: sha512-OL4OMk7UPXOeVGGd3qo5zJyPIljf4AFgk5QAkPPS+OoLuOOozhuaQGC18MxVTnw/06q93gShAJzlwnSCY9YtqA==}
+  '@rolldown/binding-win32-x64-msvc@1.1.4':
+    resolution: {integrity: sha512-M1lpniBePobTfsa7Ks9a199e1akxsXn+GYBUKsEzv3YFzOm1HJAMNwKI3qr0Zq+mxwx9gOZoTdP1yXRYsZUocQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1126,8 +1126,8 @@ packages:
   '@types/lodash@4.17.24':
     resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
 
-  '@types/node@26.0.1':
-    resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
+  '@types/node@26.1.0':
+    resolution: {integrity: sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -1870,6 +1870,10 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
@@ -2031,8 +2035,8 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
-  rolldown@1.1.3:
-    resolution: {integrity: sha512-1F1eEtUBtFvcGm1HQ9TiUIUHPQG7mSAODrhIzjxoUEFuo8OcbrGLiVLkevNgj84TE4lnHvnumwFjhJO5Eu135g==}
+  rolldown@1.1.4:
+    resolution: {integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -2297,8 +2301,8 @@ packages:
       '@vite-pwa/assets-generator':
         optional: true
 
-  vite@8.1.0:
-    resolution: {integrity: sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==}
+  vite@8.1.3:
+    resolution: {integrity: sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -3090,39 +3094,39 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@biomejs/biome@2.5.1':
+  '@biomejs/biome@2.5.2':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.5.1
-      '@biomejs/cli-darwin-x64': 2.5.1
-      '@biomejs/cli-linux-arm64': 2.5.1
-      '@biomejs/cli-linux-arm64-musl': 2.5.1
-      '@biomejs/cli-linux-x64': 2.5.1
-      '@biomejs/cli-linux-x64-musl': 2.5.1
-      '@biomejs/cli-win32-arm64': 2.5.1
-      '@biomejs/cli-win32-x64': 2.5.1
+      '@biomejs/cli-darwin-arm64': 2.5.2
+      '@biomejs/cli-darwin-x64': 2.5.2
+      '@biomejs/cli-linux-arm64': 2.5.2
+      '@biomejs/cli-linux-arm64-musl': 2.5.2
+      '@biomejs/cli-linux-x64': 2.5.2
+      '@biomejs/cli-linux-x64-musl': 2.5.2
+      '@biomejs/cli-win32-arm64': 2.5.2
+      '@biomejs/cli-win32-x64': 2.5.2
 
-  '@biomejs/cli-darwin-arm64@2.5.1':
+  '@biomejs/cli-darwin-arm64@2.5.2':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.5.1':
+  '@biomejs/cli-darwin-x64@2.5.2':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.5.1':
+  '@biomejs/cli-linux-arm64-musl@2.5.2':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.5.1':
+  '@biomejs/cli-linux-arm64@2.5.2':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.5.1':
+  '@biomejs/cli-linux-x64-musl@2.5.2':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.5.1':
+  '@biomejs/cli-linux-x64@2.5.2':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.5.1':
+  '@biomejs/cli-win32-arm64@2.5.2':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.5.1':
+  '@biomejs/cli-win32-x64@2.5.2':
     optional: true
 
   '@emnapi/core@1.11.1':
@@ -3192,12 +3196,12 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@lottiefiles/dotlottie-react@0.19.5(react@19.2.7)':
+  '@lottiefiles/dotlottie-react@0.19.7(react@19.2.7)':
     dependencies:
-      '@lottiefiles/dotlottie-web': 0.75.0
+      '@lottiefiles/dotlottie-web': 0.76.0
       react: 19.2.7
 
-  '@lottiefiles/dotlottie-web@0.75.0': {}
+  '@lottiefiles/dotlottie-web@0.76.0': {}
 
   '@mantine/core@9.4.1(@mantine/hooks@9.4.1(react@19.2.7))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
@@ -3250,65 +3254,65 @@ snapshots:
       '@tybys/wasm-util': 0.10.3
     optional: true
 
-  '@oxc-project/types@0.137.0': {}
+  '@oxc-project/types@0.138.0': {}
 
-  '@rolldown/binding-android-arm64@1.1.3':
+  '@rolldown/binding-android-arm64@1.1.4':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.1.3':
+  '@rolldown/binding-darwin-arm64@1.1.4':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.1.3':
+  '@rolldown/binding-darwin-x64@1.1.4':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.1.3':
+  '@rolldown/binding-freebsd-x64@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.1.3':
+  '@rolldown/binding-linux-arm-gnueabihf@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.1.3':
+  '@rolldown/binding-linux-arm64-gnu@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.1.3':
+  '@rolldown/binding-linux-arm64-musl@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.1.3':
+  '@rolldown/binding-linux-ppc64-gnu@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.1.3':
+  '@rolldown/binding-linux-s390x-gnu@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.1.3':
+  '@rolldown/binding-linux-x64-gnu@1.1.4':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.1.3':
+  '@rolldown/binding-linux-x64-musl@1.1.4':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.1.3':
+  '@rolldown/binding-openharmony-arm64@1.1.4':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.1.3':
+  '@rolldown/binding-wasm32-wasi@1.1.4':
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.1.3':
+  '@rolldown/binding-win32-arm64-msvc@1.1.4':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.1.3':
+  '@rolldown/binding-win32-x64-msvc@1.1.4':
     optional: true
 
-  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0))':
+  '@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0))':
     dependencies:
       '@babel/core': 7.29.7
       picomatch: 4.0.4
-      rolldown: 1.1.3
+      rolldown: 1.1.4
     optionalDependencies:
       '@babel/runtime': 7.29.7
-      vite: 8.1.0(@types/node@26.0.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0)
+      vite: 8.1.3(@types/node@26.1.0)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0)
 
   '@rolldown/pluginutils@1.0.1': {}
 
@@ -3457,7 +3461,7 @@ snapshots:
 
   '@types/lodash@4.17.24': {}
 
-  '@types/node@26.0.1':
+  '@types/node@26.1.0':
     dependencies:
       undici-types: 8.3.0
 
@@ -3473,12 +3477,12 @@ snapshots:
 
   '@types/trusted-types@2.0.7': {}
 
-  '@vitejs/plugin-react@6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0))':
+  '@vitejs/plugin-react@6.0.3(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0)))(babel-plugin-react-compiler@1.0.0)(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
-      vite: 8.1.0(@types/node@26.0.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0)
+      vite: 8.1.3(@types/node@26.1.0)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0)
     optionalDependencies:
-      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.3)(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0))
+      '@rolldown/plugin-babel': 0.2.3(@babel/core@7.29.7)(@babel/runtime@7.29.7)(rolldown@1.1.4)(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0))
       babel-plugin-react-compiler: 1.0.0
 
   acorn@8.16.0: {}
@@ -4198,6 +4202,8 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  picomatch@4.0.5: {}
+
   possible-typed-array-names@1.1.0: {}
 
   postcss-js@4.1.0(postcss@8.5.16):
@@ -4352,26 +4358,26 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  rolldown@1.1.3:
+  rolldown@1.1.4:
     dependencies:
-      '@oxc-project/types': 0.137.0
+      '@oxc-project/types': 0.138.0
       '@rolldown/pluginutils': 1.0.1
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.1.3
-      '@rolldown/binding-darwin-arm64': 1.1.3
-      '@rolldown/binding-darwin-x64': 1.1.3
-      '@rolldown/binding-freebsd-x64': 1.1.3
-      '@rolldown/binding-linux-arm-gnueabihf': 1.1.3
-      '@rolldown/binding-linux-arm64-gnu': 1.1.3
-      '@rolldown/binding-linux-arm64-musl': 1.1.3
-      '@rolldown/binding-linux-ppc64-gnu': 1.1.3
-      '@rolldown/binding-linux-s390x-gnu': 1.1.3
-      '@rolldown/binding-linux-x64-gnu': 1.1.3
-      '@rolldown/binding-linux-x64-musl': 1.1.3
-      '@rolldown/binding-openharmony-arm64': 1.1.3
-      '@rolldown/binding-wasm32-wasi': 1.1.3
-      '@rolldown/binding-win32-arm64-msvc': 1.1.3
-      '@rolldown/binding-win32-x64-msvc': 1.1.3
+      '@rolldown/binding-android-arm64': 1.1.4
+      '@rolldown/binding-darwin-arm64': 1.1.4
+      '@rolldown/binding-darwin-x64': 1.1.4
+      '@rolldown/binding-freebsd-x64': 1.1.4
+      '@rolldown/binding-linux-arm-gnueabihf': 1.1.4
+      '@rolldown/binding-linux-arm64-gnu': 1.1.4
+      '@rolldown/binding-linux-arm64-musl': 1.1.4
+      '@rolldown/binding-linux-ppc64-gnu': 1.1.4
+      '@rolldown/binding-linux-s390x-gnu': 1.1.4
+      '@rolldown/binding-linux-x64-gnu': 1.1.4
+      '@rolldown/binding-linux-x64-musl': 1.1.4
+      '@rolldown/binding-openharmony-arm64': 1.1.4
+      '@rolldown/binding-wasm32-wasi': 1.1.4
+      '@rolldown/binding-win32-arm64-msvc': 1.1.4
+      '@rolldown/binding-win32-x64-msvc': 1.1.4
 
   rollup@4.61.1:
     dependencies:
@@ -4684,26 +4690,26 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite-plugin-pwa@1.3.0(vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0))(workbox-build@7.4.1)(workbox-window@7.4.1):
+  vite-plugin-pwa@1.3.0(vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0))(workbox-build@7.4.1)(workbox-window@7.4.1):
     dependencies:
       debug: 4.4.3
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.17
-      vite: 8.1.0(@types/node@26.0.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0)
+      vite: 8.1.3(@types/node@26.1.0)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0)
       workbox-build: 7.4.1
       workbox-window: 7.4.1
     transitivePeerDependencies:
       - supports-color
 
-  vite@8.1.0(@types/node@26.0.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0):
+  vite@8.1.3(@types/node@26.1.0)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(terser@5.48.0):
     dependencies:
       lightningcss: 1.32.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       postcss: 8.5.16
-      rolldown: 1.1.3
+      rolldown: 1.1.4
       tinyglobby: 0.2.17
     optionalDependencies:
-      '@types/node': 26.0.1
+      '@types/node': 26.1.0
       fsevents: 2.3.3
       jiti: 2.7.0
       sugarss: 5.0.1(postcss@8.5.16)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,28 +1,7 @@
-import { FrameContext } from '#/helpers/frame';
-import { useContext, useEffect } from 'react';
 // App-specific imports
 import Routes from './Routes';
 
 function App() {
-  const frame = useContext(FrameContext);
-
-  // Check for showUnpublishedRecords flag
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    if (params.get('showUnpublishedRecords') === 'true') {
-      // Open the unpublished records dialog
-      frame.open(`${import.meta.env.VITE_API_BIOCOLLECT}/pwa/offlineList`, 'Unpublished Records');
-
-      // Remove the query param
-      params.delete('showUnpublishedRecords');
-      window.history.replaceState(
-        null,
-        '',
-        window.location.origin + window.location.pathname + params.toString(),
-      );
-    }
-  }, []);
-
   return <Routes />;
 }
 

--- a/src/components/DownloadChip/index.tsx
+++ b/src/components/DownloadChip/index.tsx
@@ -10,12 +10,11 @@ import { dexie } from '#/helpers/api/dexie';
 
 interface DownloadChipProps extends Omit<ButtonProps, 'children'> {
   survey?: BioCollectSurvey;
-  label?: string;
   onLine?: boolean;
   downloaded?: boolean;
 }
 
-export function DownloadChip({ survey, label, onLine, downloaded, ...rest }: DownloadChipProps) {
+export function DownloadChip({ survey, onLine, downloaded, ...rest }: DownloadChipProps) {
   const frame = useContext(FrameContext);
 
   // Handler for the download popup
@@ -88,7 +87,7 @@ export function DownloadChip({ survey, label, onLine, downloaded, ...rest }: Dow
       maw={250}
       {...rest}
     >
-      {label || (downloaded ? 'Downloaded' : 'Download')}
+      {downloaded ? 'Downloaded' : 'Download'}
     </Button>
   );
 }

--- a/src/components/SurveyActions/index.tsx
+++ b/src/components/SurveyActions/index.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Flex, type FlexProps, Skeleton, Text, Tooltip } from '@mantine/core';
+import { ActionIcon, Button, Flex, type FlexProps, Skeleton, Text, Tooltip } from '@mantine/core';
 import { IconEye, IconPlus, IconUser } from '@tabler/icons-react';
 import { useContext } from 'react';
 import { RecordsDrawerContext } from '#/helpers/drawer';
@@ -17,95 +17,53 @@ export function SurveyActions({ survey, onLine, downloaded, ...rest }: SurveyAct
   const frame = useContext(FrameContext);
 
   return (
-    <Flex gap={6} align='center' {...rest}>
-      <Text size='xs' c='dimmed'>
-        Records
-      </Text>
-      <Skeleton visible={!survey} w={28}>
-        <Tooltip label='All records' withArrow disabled={!survey} position='left'>
-          <ActionIcon
-            id={survey && `${survey.projectActivityId}ViewRecord`}
-            variant='light'
-            onClick={
-              survey &&
-              (() => {
-                drawer.open(
-                  'projectactivityrecords',
-                  {
-                    projectId: survey.projectId,
-                    projectActivityId: survey.projectActivityId,
-                  },
-                  survey.name,
-                );
-              })
-            }
-          >
-            <IconEye size='1rem' />
-          </ActionIcon>
-        </Tooltip>
+    <Flex gap={0} align='center' {...rest}>
+      <Skeleton visible={!survey}>
+        <Button
+          id={survey && `${survey.projectActivityId}ViewRecord`}
+          variant='subtle'
+          px='sm'
+          leftSection={<IconEye size='1rem' />}
+          size='xs'
+          onClick={
+            survey &&
+            (() => {
+              drawer.open(
+                survey,
+              );
+            })
+          }>
+          View records
+        </Button>
       </Skeleton>
-      <Skeleton visible={!survey} w={28}>
-        <Tooltip label='My records' withArrow disabled={!survey} position='left'>
-          <ActionIcon
-            id={survey && `${survey.projectActivityId}MyRecords`}
-            variant='light'
-            onClick={
-              survey &&
-              (() => {
-                drawer.open(
-                  'myrecords',
-                  {
-                    projectActivityId: survey.projectActivityId,
-                    fq: [
-                      `projectId:${survey.projectId}`,
-                      `projectActivityNameFacet:${survey.name}`,
-                    ],
-                  },
-                  survey.name,
-                );
-              })
-            }
-          >
-            <IconUser size='1rem' />
-          </ActionIcon>
-        </Tooltip>
-      </Skeleton>
-      <Skeleton visible={!survey} w={28}>
-        <Tooltip label='Add a record' withArrow disabled={!survey} position='left'>
-          <ActionIcon
-            id={survey && `${survey.projectActivityId}AddRecord`}
-            variant='light'
-            disabled={!onLine && !downloaded}
-            onClick={
-              survey &&
-              (() => {
-                frame.open(
-                  `${import.meta.env.VITE_API_BIOCOLLECT}/pwa/bioActivity/edit/${survey.projectActivityId
-                  }?unpublished=true`,
-                  `Add Record - ${survey.name}`,
-                  {
-                    close: () => {
-                      drawer.open(
-                        'myrecords',
-                        {
-                          projectActivityId: survey.projectActivityId,
-                          fq: [
-                            `projectId:${survey.projectId}`,
-                            `projectActivityNameFacet:${survey.name}`,
-                          ],
-                        },
-                        survey.name,
-                        true
-                      )
-                    }
-                  },
-                );
-              })
-            }
-          >
-            <IconPlus size='1rem' />
-          </ActionIcon>
-        </Tooltip>
+      <Skeleton visible={!survey}>
+        <Button
+          id={survey && `${survey.projectActivityId}AddRecord`}
+          variant='subtle'
+          disabled={!onLine && !downloaded}
+          leftSection={<IconPlus size='1rem' />}
+          size='xs'
+          onClick={
+            survey &&
+            (() => {
+              frame.open(
+                `${import.meta.env.VITE_API_BIOCOLLECT}/pwa/bioActivity/edit/${survey.projectActivityId
+                }?unpublished=true`,
+                `Add Record - ${survey.name}`,
+                {
+                  close: () => {
+                    drawer.open(
+                      survey,
+                      true
+                    )
+                  }
+                },
+              );
+            })
+          }
+        >
+          Add record
+        </Button>
       </Skeleton>
     </Flex>
   );

--- a/src/components/SurveyActions/index.tsx
+++ b/src/components/SurveyActions/index.tsx
@@ -1,5 +1,5 @@
-import { ActionIcon, Button, Flex, type FlexProps, Skeleton, Text, Tooltip } from '@mantine/core';
-import { IconEye, IconPlus, IconUser } from '@tabler/icons-react';
+import { Button, Flex, type FlexProps, Skeleton } from '@mantine/core';
+import { IconEye, IconPlus } from '@tabler/icons-react';
 import { useContext } from 'react';
 import { RecordsDrawerContext } from '#/helpers/drawer';
 import { FrameContext } from '#/helpers/frame';
@@ -18,14 +18,13 @@ export function SurveyActions({ survey, onLine, downloaded, ...rest }: SurveyAct
 
   return (
     <Flex gap={4} align='center' {...rest}>
-      <Skeleton w={115} visible={!survey}>
+      <Skeleton visible={!survey}>
         <Button
           id={survey && `${survey.projectActivityId}ViewRecord`}
           variant='subtle'
           px='sm'
           leftSection={<IconEye size='1rem' />}
           size='xs'
-          fullWidth
           onClick={
             survey &&
             (() => {
@@ -37,14 +36,13 @@ export function SurveyActions({ survey, onLine, downloaded, ...rest }: SurveyAct
           View records
         </Button>
       </Skeleton>
-      <Skeleton w={115} visible={!survey}>
+      <Skeleton visible={!survey}>
         <Button
           id={survey && `${survey.projectActivityId}AddRecord`}
           variant='subtle'
           disabled={!onLine && !downloaded}
           leftSection={<IconPlus size='1rem' />}
           size='xs'
-          fullWidth
           onClick={
             survey &&
             (() => {

--- a/src/components/SurveyActions/index.tsx
+++ b/src/components/SurveyActions/index.tsx
@@ -22,7 +22,7 @@ export function SurveyActions({ survey, onLine, downloaded, ...rest }: SurveyAct
         <Button
           id={survey && `${survey.projectActivityId}ViewRecord`}
           variant='subtle'
-          px='sm'
+          px={6}
           leftSection={<IconEye size='1rem' />}
           size='xs'
           onClick={
@@ -33,7 +33,7 @@ export function SurveyActions({ survey, onLine, downloaded, ...rest }: SurveyAct
               );
             })
           }>
-          View records
+          Records
         </Button>
       </Skeleton>
       <Skeleton visible={!survey}>
@@ -42,6 +42,7 @@ export function SurveyActions({ survey, onLine, downloaded, ...rest }: SurveyAct
           variant='subtle'
           disabled={!onLine && !downloaded}
           leftSection={<IconPlus size='1rem' />}
+          px={6}
           size='xs'
           onClick={
             survey &&
@@ -62,7 +63,7 @@ export function SurveyActions({ survey, onLine, downloaded, ...rest }: SurveyAct
             })
           }
         >
-          Add record
+          Add
         </Button>
       </Skeleton>
     </Flex>

--- a/src/components/SurveyActions/index.tsx
+++ b/src/components/SurveyActions/index.tsx
@@ -17,14 +17,15 @@ export function SurveyActions({ survey, onLine, downloaded, ...rest }: SurveyAct
   const frame = useContext(FrameContext);
 
   return (
-    <Flex gap={0} align='center' {...rest}>
-      <Skeleton visible={!survey}>
+    <Flex gap={4} align='center' {...rest}>
+      <Skeleton w={115} visible={!survey}>
         <Button
           id={survey && `${survey.projectActivityId}ViewRecord`}
           variant='subtle'
           px='sm'
           leftSection={<IconEye size='1rem' />}
           size='xs'
+          fullWidth
           onClick={
             survey &&
             (() => {
@@ -36,13 +37,14 @@ export function SurveyActions({ survey, onLine, downloaded, ...rest }: SurveyAct
           View records
         </Button>
       </Skeleton>
-      <Skeleton visible={!survey}>
+      <Skeleton w={115} visible={!survey}>
         <Button
           id={survey && `${survey.projectActivityId}AddRecord`}
           variant='subtle'
           disabled={!onLine && !downloaded}
           leftSection={<IconPlus size='1rem' />}
           size='xs'
+          fullWidth
           onClick={
             survey &&
             (() => {

--- a/src/helpers/api/index.ts
+++ b/src/helpers/api/index.ts
@@ -1,4 +1,17 @@
+import axios from 'axios';
+import { userManager } from '../auth';
 import { dexie } from './dexie';
 import biocollectApi from './endpoints/biocollect';
+
+axios.interceptors.request.use(async (config) => {
+  const user = await userManager.getUser();
+
+  // Add the authorization header if the user is authenticated
+  if (user) {
+    config.headers.Authorization = `Bearer ${user.access_token}`;
+  }
+
+  return config;
+});
 
 export const biocollect = biocollectApi(dexie);

--- a/src/helpers/drawer/components/OfflineActivityItem.tsx
+++ b/src/helpers/drawer/components/OfflineActivityItem.tsx
@@ -1,6 +1,7 @@
 import { Avatar, Badge, Button, Flex, Skeleton, Text, ThemeIcon } from '@mantine/core';
 import { modals } from '@mantine/modals';
 import {
+  IconAlertTriangle,
   IconDeviceFloppy,
   IconEye,
   IconPencil,
@@ -8,13 +9,15 @@ import {
   IconTrash,
   IconUpload,
 } from '@tabler/icons-react';
-import { useContext, useEffect, useMemo, useState } from 'react';
+import { useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import { FrameContext } from '#/helpers/frame';
 import { useOnLine } from '#/helpers/funcs';
 import type { BioCollectOfflineActivitySummary } from '#/types';
 
 import { RecordCard } from './RecordCard';
+
+const MAX_UPLOAD_ATTEMPTS = 3;
 
 interface OfflineActivityItemProps {
   activity?: BioCollectOfflineActivitySummary;
@@ -40,6 +43,8 @@ export function OfflineActivityItem({
 
   const [deleting, setDeleting] = useState<boolean>(false);
   const [uploading, setUploading] = useState<boolean>(false);
+  const [uploadError, setUploadError] = useState<boolean>(false);
+  const uploadAttempts = useRef<number>(0);
 
   const speciesText = useMemo(() => {
     const names = (activity?.species || [])
@@ -69,17 +74,28 @@ export function OfflineActivityItem({
 
     try {
       setUploading(true);
+      setUploadError(false);
       await onUpload(activity.activityId);
+    } catch {
+      if (uploadAttempts.current >= MAX_UPLOAD_ATTEMPTS) {
+        setUploadError(true);
+      }
     } finally {
       setUploading(false);
     }
   }
 
   useEffect(() => {
-    if (activity?.uploadFlag && !uploading) {
+    if (
+      activity?.uploadFlag &&
+      !uploading &&
+      !uploadError &&
+      uploadAttempts.current < MAX_UPLOAD_ATTEMPTS
+    ) {
+      uploadAttempts.current += 1;
       handleUpload();
     }
-  }, [activity, uploading]);
+  }, [activity, uploading, uploadError]);
 
   function handleDelete() {
     if (!activity || deleting || bulkUploading || !onLine || !onDelete) {
@@ -217,12 +233,22 @@ export function OfflineActivityItem({
         </Text>
       </Skeleton>
       {activity?.isInvalidDraft && !uploading && (
-        <Flex data-testid='unpublished-invalid-message' align='center' gap='xs'>
+        <Flex data-testid='unpublished-invalid-message' align='center' gap='xs' mt='xs'>
           <ThemeIcon color='orange' variant='light'>
             <IconPencilExclamation size='1rem' />
           </ThemeIcon>
-          <Text size='xs' c='orange' mt='xs'>
+          <Text size='xs' c='orange'>
             <b>Incomplete</b> - Please finish editing it before uploading.
+          </Text>
+        </Flex>
+      )}
+      {uploadError && !uploading && (
+        <Flex data-testid='unpublished-upload-error' align='center' gap='xs' mt='xs'>
+          <ThemeIcon color='red' variant='light'>
+            <IconAlertTriangle size='1rem' />
+          </ThemeIcon>
+          <Text size='xs' c='red' >
+            <b>Upload failed</b> - Tap Upload to try again.
           </Text>
         </Flex>
       )}

--- a/src/helpers/drawer/components/PublishedRecords.tsx
+++ b/src/helpers/drawer/components/PublishedRecords.tsx
@@ -1,4 +1,4 @@
-import { ActionIcon, Button, Center, Group, Loader, Stack, Text, TextInput } from '@mantine/core';
+import { ActionIcon, Button, Center, Group, Loader, SegmentedControl, Stack, Text, TextInput } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconRefresh, IconSearch, IconX } from '@tabler/icons-react';
 import {
@@ -16,13 +16,13 @@ import type {
   BioCollectBioActivity,
   BioCollectBioActivitySearch,
   BioCollectBioActivityView,
+  BioCollectSurvey,
   FilterQueries,
 } from '#/types';
 import { ActivityItem } from './ActivityItem';
 
 export interface RecordsProps {
-  view: BioCollectBioActivityView | null;
-  filters: FilterQueries;
+  survey: BioCollectSurvey;
 }
 
 interface PublishedRecordsProps extends RecordsProps {
@@ -30,8 +30,7 @@ interface PublishedRecordsProps extends RecordsProps {
 }
 
 export const PublishedRecords = ({
-  view,
-  filters,
+  survey,
   publishedRefreshKey,
 }: PropsWithChildren<PublishedRecordsProps>): ReactElement => {
   const [search, setSearch] = useState<BioCollectBioActivitySearch | null>(null);
@@ -42,6 +41,7 @@ export const PublishedRecords = ({
 
   // paging/loading more hooks
   const PAGE_SIZE = 20;
+  const [view, setView] = useState<BioCollectBioActivityView>('myrecords');
   const [page, setPage] = useState<number>(0);
   const [items, setItems] = useState<BioCollectBioActivity[]>([]);
   const [loadingMore, setLoadingMore] = useState<boolean>(false);
@@ -66,8 +66,19 @@ export const PublishedRecords = ({
 
       setLoadingMore(true);
 
+      const filters = view === 'myrecords' ? {
+        projectActivityId: survey.projectActivityId,
+        fq: [
+          `projectId:${survey.projectId}`,
+          `projectActivityNameFacet:${survey.name}`,
+        ],
+      } : {
+        projectId: survey.projectId,
+        projectActivityId: survey.projectActivityId,
+      };
+
       const pagedFilters: FilterQueries = {
-        ...(filters || {}),
+        ...filters,
         ...(debouncedSearchTerm ? { searchTerm: debouncedSearchTerm } : {}),
         offset: String(page * PAGE_SIZE),
         max: String(PAGE_SIZE),
@@ -83,7 +94,7 @@ export const PublishedRecords = ({
     }
 
     getActivities();
-  }, [view, filters, publishedRefreshKey, refreshSwitch, debouncedSearchTerm, page]);
+  }, [view, publishedRefreshKey, refreshSwitch, debouncedSearchTerm, page]);
 
   function clearSearch() {
     setSearchInput('');
@@ -100,7 +111,7 @@ export const PublishedRecords = ({
   );
 
   return (
-    <Stack pb='sm'>
+    <Stack gap='xs' pb='sm'>
       <Group>
         <TextInput
           value={searchInput}
@@ -139,7 +150,12 @@ export const PublishedRecords = ({
           Refresh
         </Button>
       </Group>
-
+      <SegmentedControl
+        value={view}
+        onChange={setView}
+        disabled={loadingMore}
+        data={[{ label: 'My Records', value: 'myrecords' }, { label: 'All records', value: 'projectactivityrecords' }]}
+      />
       {(() => {
         if (search) {
           return items.length > 0 ? (

--- a/src/helpers/drawer/components/PublishedRecords.tsx
+++ b/src/helpers/drawer/components/PublishedRecords.tsx
@@ -55,6 +55,14 @@ export const PublishedRecords = ({
     setRefreshSwitch((prevSwitch) => !prevSwitch);
   }, []);
 
+  const handleViewChange = useCallback((value: string) => {
+    setView(value as BioCollectBioActivityView);
+    setSearch(null);
+    setItems([]);
+    setPage(0);
+    setHasMore(true);
+  }, []);
+
   // load next page
   const loadMore = () => {
     if (!loadingMore && hasMore) setPage((p) => p + 1);
@@ -66,15 +74,16 @@ export const PublishedRecords = ({
 
       setLoadingMore(true);
 
-      const filters = view === 'myrecords' ? {
-        projectActivityId: survey.projectActivityId,
+      const filters: FilterQueries = view === 'myrecords' ? {
         fq: [
           `projectId:${survey.projectId}`,
           `projectActivityNameFacet:${survey.name}`,
         ],
       } : {
         projectId: survey.projectId,
-        projectActivityId: survey.projectActivityId,
+        fq: [
+          `projectActivityNameFacet:${survey.name}`,
+        ],
       };
 
       const pagedFilters: FilterQueries = {
@@ -115,7 +124,11 @@ export const PublishedRecords = ({
       <Group>
         <TextInput
           value={searchInput}
-          onChange={(e) => setSearchInput(e.currentTarget.value)}
+          onChange={(e) => {
+            setSearchInput(e.currentTarget.value);
+            setPage(0);
+            setHasMore(true);
+          }}
           placeholder='Search activities…'
           leftSection={<IconSearch size={16} />}
           rightSection={(() => {
@@ -152,9 +165,9 @@ export const PublishedRecords = ({
       </Group>
       <SegmentedControl
         value={view}
-        onChange={setView}
+        onChange={handleViewChange}
         disabled={loadingMore}
-        data={[{ label: 'My Records', value: 'myrecords' }, { label: 'All records', value: 'projectactivityrecords' }]}
+        data={[{ label: 'My Records', value: 'myrecords' }, { label: 'All records', value: 'project' }]}
       />
       {(() => {
         if (search) {

--- a/src/helpers/drawer/components/PublishedRecords.tsx
+++ b/src/helpers/drawer/components/PublishedRecords.tsx
@@ -163,7 +163,7 @@ export const PublishedRecords = ({
         data={[
           {
             label: (
-              <Flex justify='center' align='center' gap='xs' p={4}>
+              <Flex id='myRecords' justify='center' align='center' gap='xs' p={4}>
                 <IconUser size='0.8rem' />
                 <Text fw='bold' size='sm'>My Records</Text>
               </Flex>
@@ -172,7 +172,7 @@ export const PublishedRecords = ({
           },
           {
             label: (
-              <Flex justify='center' align='center' gap='xs' p={4}>
+              <Flex id='allRecords' justify='center' align='center' gap='xs' p={4}>
                 <IconUsersGroup size='0.8rem' />
                 <Text fw='bold' size='sm'>All Records</Text>
               </Flex>

--- a/src/helpers/drawer/components/PublishedRecords.tsx
+++ b/src/helpers/drawer/components/PublishedRecords.tsx
@@ -1,6 +1,6 @@
-import { ActionIcon, Button, Center, Group, Loader, SegmentedControl, Stack, Text, TextInput } from '@mantine/core';
+import { ActionIcon, Button, Center, Flex, Group, SegmentedControl, Stack, Text, TextInput } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
-import { IconRefresh, IconSearch, IconX } from '@tabler/icons-react';
+import { IconRefresh, IconSearch, IconUser, IconUsersGroup, IconX } from '@tabler/icons-react';
 import {
   Fragment,
   type PropsWithChildren,
@@ -131,26 +131,18 @@ export const PublishedRecords = ({
           }}
           placeholder='Search activities…'
           leftSection={<IconSearch size={16} />}
-          rightSection={(() => {
-            if (loadingMore) {
-              return <Loader size='xs' />;
-            } else if (searchInput) {
-              return (
-                <ActionIcon
-                  aria-label='Clear search'
-                  onClick={clearSearch}
-                  onMouseDown={(e) => e.preventDefault()}
-                  variant='subtle'
-                >
-                  <IconX size={16} />
-                </ActionIcon>
-              );
-            }
-            return null;
-          })()}
+          rightSection={searchInput.length > 0 && (<ActionIcon
+            aria-label='Clear search'
+            onClick={clearSearch}
+            onMouseDown={(e) => e.preventDefault()}
+            variant='subtle'
+          >
+            <IconX size={16} />
+          </ActionIcon>)
+          }
           rightSectionWidth={36}
           aria-label='Search published activities'
-          disabled={loadingMore || !search}
+          disabled={!search}
           style={{ flexGrow: 1 }}
         />
         <Button
@@ -167,7 +159,27 @@ export const PublishedRecords = ({
         value={view}
         onChange={handleViewChange}
         disabled={loadingMore}
-        data={[{ label: 'My Records', value: 'myrecords' }, { label: 'All records', value: 'project' }]}
+        radius='xl'
+        data={[
+          {
+            label: (
+              <Flex justify='center' align='center' gap='xs' p={4}>
+                <IconUser size='0.8rem' />
+                <Text fw='bold' size='sm'>My Records</Text>
+              </Flex>
+            ),
+            value: 'myrecords'
+          },
+          {
+            label: (
+              <Flex justify='center' align='center' gap='xs' p={4}>
+                <IconUsersGroup size='0.8rem' />
+                <Text fw='bold' size='sm'>All Records</Text>
+              </Flex>
+            ),
+            value: 'project'
+          }
+        ]}
       />
       {(() => {
         if (search) {

--- a/src/helpers/drawer/components/UnpublishedRecords.tsx
+++ b/src/helpers/drawer/components/UnpublishedRecords.tsx
@@ -1,5 +1,5 @@
 import { Alert, Button, Center, Group, Progress, Stack, Text } from '@mantine/core';
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useMemo, useState } from 'react';
 
 import { useOnLine } from '#/helpers/funcs';
 import { usePWA, useUnpublished } from '#/helpers/pwa';
@@ -13,7 +13,7 @@ interface UnpublishedRecordsProps extends RecordsProps {
   onMutation?: () => void;
 }
 
-export function UnpublishedRecords({ filters, onMutation }: UnpublishedRecordsProps) {
+export function UnpublishedRecords({ survey, onMutation }: UnpublishedRecordsProps) {
   const pwa = usePWA();
   const onLine = useOnLine();
   const { unpublished, unpublishedError, unpublishedLoading, refresh } = useUnpublished({
@@ -24,7 +24,7 @@ export function UnpublishedRecords({ filters, onMutation }: UnpublishedRecordsPr
   const [uploadProgress, setUploadProgress] = useState<OfflineUploadAllProgress | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  const projectActivityId = filters.projectActivityId as string | undefined;
+  const projectActivityId = survey.projectActivityId as string | undefined;
 
   const items = useMemo(
     () =>

--- a/src/helpers/drawer/context.ts
+++ b/src/helpers/drawer/context.ts
@@ -1,11 +1,9 @@
 import { createContext } from 'react';
-import type { BioCollectBioActivityView, FilterQueries } from '#/types';
+import type { BioCollectSurvey } from '#/types';
 
 interface RecordsDrawerContext {
   open: (
-    view: BioCollectBioActivityView,
-    fq?: FilterQueries,
-    recordsFor?: string,
+    survey: BioCollectSurvey,
     showUnpublished?: boolean,
   ) => void;
   close: () => void;

--- a/src/helpers/drawer/provider.tsx
+++ b/src/helpers/drawer/provider.tsx
@@ -64,7 +64,7 @@ const RecordsDrawerProvider = (props: PropsWithChildren): ReactElement => {
 
   return (
     <RecordsDrawerContext.Provider value={{ open, close }}>
-      <Drawer.Root opened={opened} onClose={close} position={mobile ? 'bottom' : 'right'}>
+      <Drawer.Root opened={opened} onClose={close} position={mobile ? 'bottom' : 'right'} size={mobile ? '100%' : 'md'}>
         <Drawer.Overlay
           blur={3}
           opacity={0.55}

--- a/src/helpers/drawer/provider.tsx
+++ b/src/helpers/drawer/provider.tsx
@@ -2,7 +2,6 @@ import {
   Alert,
   Drawer,
   Group,
-  Paper,
   Stack,
   Tabs,
   Text,
@@ -13,7 +12,7 @@ import { useDisclosure, useMediaQuery } from '@mantine/hooks';
 import { type PropsWithChildren, type ReactElement, useState } from 'react';
 
 // Helpers
-import type { BioCollectBioActivityView, FilterQueries } from '#/types';
+import type { BioCollectSurvey } from '#/types';
 
 // Local components
 import RecordsDrawerContext from './context';
@@ -23,25 +22,10 @@ import { UnpublishedRecords } from './components/UnpublishedRecords';
 import { useOnLine } from '../funcs';
 import { IconDatabaseExclamation } from '@tabler/icons-react';
 
-const viewToHeader: { [key: string]: string } = {
-  myrecords: 'My Records',
-  project: 'Project',
-  projectrecords: 'Project Records',
-  myprojectrecords: 'My Records',
-  userprojectactivityrecords: 'My Records',
-  allrecords: 'Records',
-  projectactivityrecords: 'Project Records',
-};
-
 const RecordsDrawerProvider = (props: PropsWithChildren): ReactElement => {
-  const [recordsFor, setRecordsFor] = useState<string | null>(null);
-  const [view, setView] = useState<BioCollectBioActivityView | null>(null);
-  const [filters, setFilters] = useState<FilterQueries>({});
+  const [survey, setSurvey] = useState<BioCollectSurvey | null>(null);
   const [opened, { open: openDrawer, close }] = useDisclosure(false);
-
-  // Unpublished state helpers
   const [initialUnpublished, setInitialUnpublished] = useState<boolean>(false);
-
   const [publishedRefreshKey, setPublishedRefreshKey] = useState(0);
 
   const theme = useMantineTheme();
@@ -51,7 +35,7 @@ const RecordsDrawerProvider = (props: PropsWithChildren): ReactElement => {
   });
   const isOnline = useOnLine();
 
-  const projectActivityId = filters.projectActivityId as string | undefined;
+  const projectActivityId = survey?.projectActivityId as string | undefined;
   const unpublishedCount = projectActivityId
     ? unpublishedMap.projectActivity[projectActivityId] || 0
     : 0;
@@ -59,23 +43,17 @@ const RecordsDrawerProvider = (props: PropsWithChildren): ReactElement => {
 
   // Callback function to open the records drawer
   const open = async (
-    newView: BioCollectBioActivityView,
-    newFilters?: FilterQueries,
-    newRecordsFor?: string,
+    newSurvey: BioCollectSurvey,
     showUnpublished?: boolean,
   ) => {
-    if (newView) setView(newView);
-    if (newFilters) setFilters(newFilters);
-    if (newRecordsFor) setRecordsFor(newRecordsFor);
+    setSurvey(newSurvey)
 
-    if (newFilters?.projectActivityId) {
-      const newUnpublishedCount = newFilters?.projectActivityId
-        ? unpublishedMap.projectActivity[newFilters?.projectActivityId as string] || 0
-        : 0;
+    const newUnpublishedCount = newSurvey.projectActivityId
+      ? unpublishedMap.projectActivity[newSurvey.projectActivityId as string] || 0
+      : 0;
 
-      setInitialUnpublished(showUnpublished || newUnpublishedCount > 0);
-      await refreshAllUnpublished();
-    }
+    setInitialUnpublished(showUnpublished || newUnpublishedCount > 0);
+    await refreshAllUnpublished();
 
     openDrawer();
   };
@@ -96,10 +74,10 @@ const RecordsDrawerProvider = (props: PropsWithChildren): ReactElement => {
           <Drawer.Header>
             <Group gap='md'>
               <Stack gap={0}>
-                <Title order={3}>{viewToHeader[view || ''] || 'Records'}</Title>
-                {recordsFor && (
+                <Title order={3}>Records</Title>
+                {survey && (
                   <Text size='sm' c='dimmed'>
-                    For {recordsFor}
+                    For {survey.name}
                   </Text>
                 )}
               </Stack>
@@ -119,34 +97,31 @@ const RecordsDrawerProvider = (props: PropsWithChildren): ReactElement => {
                 completed
               </Alert>
             )}
-            <Tabs
+            {survey && (<Tabs
               defaultValue={!isOnline || initialUnpublished ? 'unpublished' : 'published'}
-              variant='pills'
+              radius={0}
             >
-              <Paper withBorder mb='sm' p={4} radius='xl' shadow='md'>
-                <Tabs.List grow>
-                  <Tabs.Tab
-                    id='unpublishedTab'
-                    value='unpublished'
-                  >
-                    Unpublished
-                  </Tabs.Tab>
-                  <Tabs.Tab id='publishedTab' value='published' disabled={!isOnline}>
-                    Published
-                  </Tabs.Tab>
-                </Tabs.List>
-              </Paper>
+              <Tabs.List mb='sm' mx={-16} grow>
+                <Tabs.Tab
+                  id='unpublishedTab'
+                  value='unpublished'
+                >
+                  Unpublished
+                </Tabs.Tab>
+                <Tabs.Tab id='publishedTab' value='published' disabled={!isOnline}>
+                  Published
+                </Tabs.Tab>
+              </Tabs.List>
               <Tabs.Panel value='unpublished'>
-                <UnpublishedRecords view={view} filters={filters} onMutation={handleMutation} />
+                <UnpublishedRecords survey={survey} onMutation={handleMutation} />
               </Tabs.Panel>
               <Tabs.Panel value='published'>
                 <PublishedRecords
                   publishedRefreshKey={publishedRefreshKey}
-                  view={view}
-                  filters={filters}
+                  survey={survey}
                 />
               </Tabs.Panel>
-            </Tabs>
+            </Tabs>)}
           </Drawer.Body>
         </Drawer.Content>
       </Drawer.Root>

--- a/src/layout/TokenHandler.tsx
+++ b/src/layout/TokenHandler.tsx
@@ -1,5 +1,3 @@
-import axios from 'axios';
-
 import { useCallback, useEffect } from 'react';
 import { useAuth } from 'react-oidc-context';
 
@@ -39,11 +37,6 @@ export function TokenHandler() {
       refreshHandler = setInterval(() => {
         tryTokenRefresh('interval hook');
       }, refreshInterval || 600000);
-
-      axios.defaults.headers.Authorization = `Bearer ${auth.user?.access_token}`;
-      axios.defaults.timeout = import.meta.env.VITE_API_TIMEOUT;
-    } else {
-      delete axios.defaults.headers.Authorization;
     }
 
     return () => {

--- a/src/views/Home/components/ProjectItem.module.css
+++ b/src/views/Home/components/ProjectItem.module.css
@@ -1,3 +1,0 @@
-.download {
-  max-width: min(max(125px, calc(100vw - 300px)), 240px) !important;
-}

--- a/src/views/Home/components/ProjectItem.tsx
+++ b/src/views/Home/components/ProjectItem.tsx
@@ -197,7 +197,7 @@ export function ProjectItem({
           ) : (
             <>
               {surveys.length > 0 ? (
-                <ScrollArea h={85} type='auto'>
+                <ScrollArea h={87} type='auto'>
                   <Stack px='md' pt='sm' pb='md' gap='md'>
                     {surveys.sort((survey) => unpublished?.projectActivity[survey.projectActivityId] ? -1 : 1).map((survey, index) => (
                       <ProjectItemSurvey

--- a/src/views/Home/components/ProjectItem.tsx
+++ b/src/views/Home/components/ProjectItem.tsx
@@ -22,7 +22,6 @@ import { Corner } from '#/components/Wave';
 import type { BioCollectProject, BioCollectSurvey } from '#/types';
 import { useOnLine } from '#/helpers/funcs';
 
-import classes from './ProjectItem.module.css';
 import type { OfflineProjectActivitiesMap } from '#/helpers/pwa/context';
 
 interface ProjectItemSurveyProps {
@@ -35,26 +34,29 @@ function ProjectItemSurvey({ survey, downloaded, unpublishedCount = 0 }: Project
   const onLine = useOnLine();
 
   return (
-    <Group justify='space-between'>
-      <Box style={{ minWidth: 0 }}>
-        <Skeleton visible={!survey} radius='lg'>
-          {!survey ? (
-            <Chip>Placeholder Chip</Chip>
-          ) : (
-            <DownloadChip
-              className={classes.download}
-              survey={survey}
-              label={survey.name}
-              onLine={onLine}
-              downloaded={downloaded}
-            />
-          )}
-        </Skeleton>
-      </Box>
-      <UnpublishedWrapper count={unpublishedCount}>
-        <SurveyActions survey={survey} onLine={onLine} downloaded={downloaded} />
-      </UnpublishedWrapper>
-    </Group>
+    <Stack gap='xs'>
+      <Skeleton visible={!survey}>
+        <Text size='xs'>{survey?.name || "Survey Name"}</Text>
+      </Skeleton>
+      <Group justify='space-between'>
+        <Box style={{ minWidth: 0 }}>
+          <Skeleton visible={!survey} radius='lg'>
+            {!survey ? (
+              <Chip>Placeholder Chip</Chip>
+            ) : (
+              <DownloadChip
+                survey={survey}
+                onLine={onLine}
+                downloaded={downloaded}
+              />
+            )}
+          </Skeleton>
+        </Box>
+        <UnpublishedWrapper count={unpublishedCount}>
+          <SurveyActions survey={survey} onLine={onLine} downloaded={downloaded} />
+        </UnpublishedWrapper>
+      </Group>
+    </Stack>
   );
 }
 
@@ -86,7 +88,7 @@ export function ProjectItem({
     <Grid.Col span={{ xl: 4, lg: 6, md: 6, sm: 12, xs: 12 }}>
       <Paper
         pos='relative'
-        style={{ display: 'flex', flexDirection: 'column' }}
+        style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
         shadow='xl'
         radius='xl'
         withBorder
@@ -175,19 +177,15 @@ export function ProjectItem({
         </Box>
         <Stack gap={0} mt='auto'>
           <Divider
+            mt='sm'
             labelPosition='center'
-            label={
-              <Skeleton visible={loading} w={42}>
-                Surveys
-              </Skeleton>
-            }
-            mb={6}
+            label={`${surveys.length} surveys`}
           />
-          <ScrollArea h={90} type='auto'>
-            <Stack px='md' mb='md' gap='sm'>
+          <ScrollArea h={85} type='auto'>
+            <Stack px='md' py='sm' gap='md'>
               {loading && <ProjectItemSurvey />}
               {(!loading && surveys.length > 0) &&
-                surveys.sort((survey) => unpublished?.projectActivity[survey.projectActivityId] ? -1 : 1).map((survey) => (
+                surveys.sort((survey) => unpublished?.projectActivity[survey.projectActivityId] ? -1 : 1).map((survey, index) => (
                   <ProjectItemSurvey
                     key={survey.id}
                     survey={survey}

--- a/src/views/Home/components/ProjectItem.tsx
+++ b/src/views/Home/components/ProjectItem.tsx
@@ -37,7 +37,7 @@ function ProjectItemSurvey({ survey, downloaded, unpublishedCount = 0 }: Project
   return (
     <Stack gap='xs'>
       <Skeleton visible={!survey}>
-        <Text size='xs'>{survey?.name || "Survey Name"}</Text>
+        <Text size='xs' lineClamp={1}>{survey?.name || "Survey Name"}</Text>
       </Skeleton>
       <Group justify='space-between'>
         <Box style={{ minWidth: 0 }}>

--- a/src/views/Home/components/ProjectItem.tsx
+++ b/src/views/Home/components/ProjectItem.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Button,
+  Center,
   Chip,
   Divider,
   Grid,
@@ -179,28 +180,37 @@ export function ProjectItem({
           <Divider
             mt='sm'
             labelPosition='center'
-            label={`${surveys.length} surveys`}
+            label={`${surveys.length} survey${surveys.length === 1 ? '' : 's'}`}
+            variant='dashed'
           />
-          <ScrollArea h={85} type='auto'>
-            <Stack px='md' py='sm' gap='md'>
-              {loading && <ProjectItemSurvey />}
-              {(!loading && surveys.length > 0) &&
-                surveys.sort((survey) => unpublished?.projectActivity[survey.projectActivityId] ? -1 : 1).map((survey, index) => (
-                  <ProjectItemSurvey
-                    key={survey.id}
-                    survey={survey}
-                    downloaded={downloaded?.[survey.id]}
-                    unpublishedCount={unpublished?.projectActivity[survey.projectActivityId] || 0}
-                  />
-                ))
-              }
-              {(!loading && surveys.length === 0) && (
-                <Text ta='center' size='sm' c='dimmed' h={28.2}>
-                  No surveys available
-                </Text>
-              )}
+          {loading ? (
+            <Stack px='md' py='sm'>
+              <ProjectItemSurvey />
             </Stack>
-          </ScrollArea>
+          ) : (
+            <>
+              {surveys.length > 0 ? (
+                <ScrollArea h={85} type='auto'>
+                  <Stack px='md' py='sm' gap='md'>
+                    {surveys.sort((survey) => unpublished?.projectActivity[survey.projectActivityId] ? -1 : 1).map((survey, index) => (
+                      <ProjectItemSurvey
+                        key={survey.id}
+                        survey={survey}
+                        downloaded={downloaded?.[survey.id]}
+                        unpublishedCount={unpublished?.projectActivity[survey.projectActivityId] || 0}
+                      />
+                    ))}
+                  </Stack>
+                </ScrollArea>
+              ) : (
+                <Center h={85}>
+                  <Text ta='center' size='sm' c='dimmed'>
+                    No surveys available
+                  </Text>
+                </Center>
+              )}
+            </>
+          )}
         </Stack>
       </Paper>
     </Grid.Col>

--- a/src/views/Home/components/ProjectItem.tsx
+++ b/src/views/Home/components/ProjectItem.tsx
@@ -71,10 +71,13 @@ export function ProjectItem({
 }: ProjectItemProps) {
   const loading = !project;
   const surveys = project?.projectActivities || [];
+
   const [imageLoaded, setImageLoaded] = useState<boolean>(false);
   const [imageError, setImageError] = useState<boolean>(false);
+
   const unpublishedCount = unpublished?.project[project?.projectId || ''];
   const href = project ? `/project/${project.projectId}` : '';
+
   const isTransitioning = useViewTransitionState(href);
   const imageTransitionName = isTransitioning && project ? `project-image-${project.projectId}` : 'none';
   const titleTransitionName = isTransitioning && project ? `project-title-${project.projectId}` : 'none';

--- a/src/views/Home/components/ProjectItem.tsx
+++ b/src/views/Home/components/ProjectItem.tsx
@@ -4,6 +4,7 @@ import {
   Center,
   Chip,
   Divider,
+  Flex,
   Grid,
   Group,
   Image,
@@ -12,13 +13,14 @@ import {
   Skeleton,
   Stack,
   Text,
+  ThemeIcon,
 } from '@mantine/core';
 import { IconArrowUpRight } from '@tabler/icons-react';
 import { useState } from 'react';
 import { Link, useViewTransitionState } from 'react-router';
 
 import { Background, DownloadChip, SurveyActions } from '#/components';
-import { UnpublishedBadge, UnpublishedWrapper } from '#/components/Unpublished';
+import { UnpublishedBadge } from '#/components/Unpublished';
 import { Corner } from '#/components/Wave';
 import type { BioCollectProject, BioCollectSurvey } from '#/types';
 import { useOnLine } from '#/helpers/funcs';
@@ -37,7 +39,14 @@ function ProjectItemSurvey({ survey, downloaded, unpublishedCount = 0 }: Project
   return (
     <Stack gap='xs'>
       <Skeleton visible={!survey}>
-        <Text size='xs' lineClamp={1}>{survey?.name || "Survey Name"}</Text>
+        <Flex h={18} gap='xs' align='center'>
+          {unpublishedCount > 0 && (
+            <ThemeIcon variant='light' color='yellow' size='xs'>
+              <Text fw='bold' size='xs'>{unpublishedCount}</Text>
+            </ThemeIcon>
+          )}
+          <Text size='xs' lineClamp={1}>{survey?.name || "Survey Name"}</Text>
+        </Flex>
       </Skeleton>
       <Group justify='space-between'>
         <Box style={{ minWidth: 0 }}>
@@ -53,9 +62,7 @@ function ProjectItemSurvey({ survey, downloaded, unpublishedCount = 0 }: Project
             )}
           </Skeleton>
         </Box>
-        <UnpublishedWrapper count={unpublishedCount}>
-          <SurveyActions survey={survey} onLine={onLine} downloaded={downloaded} />
-        </UnpublishedWrapper>
+        <SurveyActions survey={survey} onLine={onLine} downloaded={downloaded} />
       </Group>
     </Stack>
   );

--- a/src/views/Home/components/ProjectItem.tsx
+++ b/src/views/Home/components/ProjectItem.tsx
@@ -191,7 +191,7 @@ export function ProjectItem({
             <>
               {surveys.length > 0 ? (
                 <ScrollArea h={85} type='auto'>
-                  <Stack px='md' py='sm' gap='md'>
+                  <Stack px='md' pt='sm' pb='md' gap='md'>
                     {surveys.sort((survey) => unpublished?.projectActivity[survey.projectActivityId] ? -1 : 1).map((survey, index) => (
                       <ProjectItemSurvey
                         key={survey.id}

--- a/src/views/Welcome/index.tsx
+++ b/src/views/Welcome/index.tsx
@@ -1,9 +1,7 @@
 import {
-  ActionIcon,
   Button,
   Card,
   Group,
-  Image,
   List,
   Paper,
   Stack,
@@ -13,11 +11,14 @@ import {
   useMantineTheme,
 } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
-import { IconArrowRight, IconEye, IconHandFinger, IconPlus, IconSearch } from '@tabler/icons-react';
+import { IconArrowRight, IconArrowUpRight, IconDownload, IconEye, IconHandFinger, IconPlus, IconSearch } from '@tabler/icons-react';
 import { useNavigate } from 'react-router';
 
-import { Background, DownloadChip } from '#/components';
+import { Background } from '#/components';
 import { Logo } from '#/components/Logo';
+
+const LINE_HEIGHT = 1.65;
+const ICON_MARGIN = 4;
 
 function WelcomeDetails() {
   const navigate = useNavigate();
@@ -31,14 +32,15 @@ function WelcomeDetails() {
           Welcome to the web-based BioCollect mobile app
         </Text>
       </Stack>
-      <Card px='sm' pt='xs' pb='lg' my='xl' style={{ textAlign: 'left' }} withBorder>
+      <Card px='md' pt='xs' pb='lg' my='xl' style={{ textAlign: 'left' }} radius='xl' withBorder>
         <Text size='xs' fw='bold' c='dimmed' tt='uppercase' mb='sm' style={{ textAlign: 'center' }}>
           How to use
         </Text>
-        <List spacing='xs' size='sm' center>
+        <List pl={0} spacing='sm' size='sm' center>
           <List.Item
+            lh={LINE_HEIGHT}
             icon={
-              <ThemeIcon variant='light' size={24} radius='xl'>
+              <ThemeIcon variant='light' size={24} radius='xl' mr={ICON_MARGIN}>
                 <IconSearch size='0.9rem' />
               </ThemeIcon>
             }
@@ -46,60 +48,65 @@ function WelcomeDetails() {
             Search for projects of interest
           </List.Item>
           <List.Item
+            lh={LINE_HEIGHT}
             icon={
-              <ThemeIcon variant='light' size={24} radius='xl'>
+              <ThemeIcon variant='light' size={24} radius='xl' mr={ICON_MARGIN}>
                 <IconHandFinger size='0.9rem' />
               </ThemeIcon>
             }
           >
             Press
-            <DownloadChip onLine display='inline' mx={6} /> to save surveys for offline use
+            <Button size='xs' mx={6} display='inline-flex' variant='light' leftSection={<IconDownload size='1rem' />}>
+              Download
+            </Button>
+            to save surveys for offline use
           </List.Item>
           <List.Item
+            lh={LINE_HEIGHT}
             icon={
-              <ThemeIcon variant='light' size={24} radius='xl'>
+              <ThemeIcon variant='light' size={24} radius='xl' mr={ICON_MARGIN}>
                 <IconHandFinger size='0.9rem' />
               </ThemeIcon>
             }
           >
             The
-            <Group mx={6} gap={6} display='inline-flex'>
-              <ActionIcon display='inline-flex' variant='light'>
-                <IconEye size='1rem' />
-              </ActionIcon>
-              <ActionIcon display='inline-flex' variant='light'>
-                <IconPlus size='1rem' />
-              </ActionIcon>
-            </Group>
+            <Button ml={6} mr={3} size='xs' display='inline-flex' variant='light' leftSection={<IconEye size='1rem' />}>
+              Records
+            </Button>
+            <Button ml={3} mr={6} size='xs' display='inline-flex' variant='light' leftSection={<IconPlus size='1rem' />}>
+              Add
+            </Button>
             buttons let you view/add records
           </List.Item>
           <List.Item
+            lh={LINE_HEIGHT}
             icon={
-              <ThemeIcon variant='light' size={24} radius='xl'>
+              <ThemeIcon variant='light' size={24} radius='xl' mr={ICON_MARGIN}>
                 <IconEye size='0.8rem' />
               </ThemeIcon>
             }
           >
-            <Group gap={6}>
-              Press
-              <b>View project</b>
-              to see more detailed project information
-            </Group>
+
+            Press
+            <Button size='xs' variant='outline' mx={6} rightSection={<IconArrowUpRight size="1rem" />}>
+              View project
+            </Button>
+            to see more detailed project information
           </List.Item>
         </List>
       </Card>
       <Button
         id='getStarted'
+        radius='xl'
         onClick={() => {
           localStorage.setItem('pwa-welcome', 'true');
           navigate('/', { viewTransition: true });
         }}
-        rightSection={<IconArrowRight />}
-        mt='md'
+        rightSection={<IconArrowRight size='1rem' />}
       >
         Get started
       </Button>
-    </Stack>
+    </Stack >
   );
 }
 
@@ -119,7 +126,7 @@ export function Welcome() {
         height: '100vh',
       }}
     >
-      <Paper radius='lg' p='md' shadow='lg'>
+      <Paper radius='xl' p='md' shadow='xl'>
         <WelcomeDetails />
       </Paper>
     </Background>


### PR DESCRIPTION
- Added a maximum of 3 retries when uploading an unpublished activity
  - If all 3 attempts fail, the `UnpublishedRecord` card now shows an error state, and the user can manually re-submit via the upload button
- Fixed an edge case where some requests are sent before the app's auth is initialized & the default authorization header is set
- Improved the project card & records drawer UI
  - The full survey name is now visible above the survey actions
    - The number of unpublished records is to the left of the name
  - The `All records` and `My records` buttons have been unified into a `View records` button
    - This button, and the `Add record` button now both have more descriptive text
  - The `Published` tab in the records drawer now lets you switch between `All` and `My` records
  - The records drawer now assumes 100% of the viewport height on mobile
- Updated the welcome page to reflect the new UI